### PR TITLE
feat: add questionnaire and chat assessment endpoints

### DIFF
--- a/backend/api/assessment.py
+++ b/backend/api/assessment.py
@@ -1,0 +1,50 @@
+"""Assessment endpoints for delivering questionnaires and grading answers."""
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+from typing import Dict, List
+
+from services.questionnaire import load_questionnaire, evaluate_answers
+
+router = APIRouter(prefix="/assessment", tags=["assessment"])
+
+
+class Question(BaseModel):
+    id: str
+    question: str
+    choices: List[str]
+
+
+class AnswersIn(BaseModel):
+    module_id: str = Field(..., description="课程模块ID")
+    answers: Dict[str, str] = Field(..., description="qid -> user's choice")
+
+
+class ScoreOut(BaseModel):
+    score: float
+    level: str
+    weak_topics: List[str]
+    recommendations: List[str]
+
+
+@router.get("/{module_id}", response_model=List[Question])
+async def get_questionnaire(module_id: str):
+    """Return questionnaire for a given module."""
+    try:
+        return load_questionnaire(module_id)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail="Failed to load questionnaire") from exc
+
+
+@router.post("/grade", response_model=ScoreOut)
+async def grade_answers(payload: AnswersIn):
+    """Evaluate answers and compute user's level."""
+    try:
+        result = evaluate_answers(payload.module_id, payload.answers)
+        return ScoreOut(**result)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail="Failed to evaluate answers") from exc
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
 # backend/main.py
 from fastapi import FastAPI
 from api.chat import router as chat_router
+from api.assessment import router as assessment_router
 
 app = FastAPI(title="Just Governance API", version="0.1.0")
 
@@ -22,3 +23,4 @@ def healthz():
 
 # AI 路由
 app.include_router(chat_router, prefix="/ai")
+app.include_router(assessment_router)

--- a/backend/prompts/governance.json
+++ b/backend/prompts/governance.json
@@ -1,1 +1,8 @@
-{}
+{
+  "system": "You are the Just Governance (JG) tutoring bot. Provide clear and friendly explanations about governance topics.",
+  "style": {
+    "tone": "supportive",
+    "language": "English"
+  },
+  "guardrails": "If you are unsure about an answer, admit it and encourage the student to consult additional resources."
+}

--- a/backend/prompts/questionnaires.json
+++ b/backend/prompts/questionnaires.json
@@ -1,0 +1,40 @@
+{
+  "governance_basics": [
+    {
+      "id": "q1",
+      "question": "What is the primary purpose of corporate governance?",
+      "choices": [
+        "Ensuring compliance with tax laws",
+        "Balancing the interests of stakeholders",
+        "Preparing marketing campaigns",
+        "Designing product features"
+      ],
+      "answer": "B",
+      "topic": "purpose"
+    },
+    {
+      "id": "q2",
+      "question": "Who typically holds fiduciary duties in a corporation?",
+      "choices": [
+        "Shareholders",
+        "Board directors",
+        "Employees",
+        "Customers"
+      ],
+      "answer": "B",
+      "topic": "board_roles"
+    },
+    {
+      "id": "q3",
+      "question": "Which document often outlines the rights of shareholders?",
+      "choices": [
+        "Articles of association",
+        "Invoice",
+        "Employment contract",
+        "Internal memo"
+      ],
+      "answer": "A",
+      "topic": "shareholder_rights"
+    }
+  ]
+}

--- a/backend/services/gpt_call.py
+++ b/backend/services/gpt_call.py
@@ -73,3 +73,30 @@ async def explain_topic(module_id: str, subtopic: str, known_points: list[str], 
             explanation=text,
             checklist=[],
         ).model_dump()
+
+
+async def ask_question(question: str, level: str) -> str:
+    """Simple question answering based on user level."""
+    tmpl = _load_prompt_template()
+    system_prompt = tmpl.get("system", "")
+    style = tmpl.get("style", {})
+    guardrails = tmpl.get("guardrails", "")
+
+    user_content = {
+        "task": "answer_question",
+        "question": question,
+        "level": level,
+        "style": style,
+        "guardrails": guardrails,
+    }
+
+    resp = client.chat.completions.create(
+        model=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": json.dumps(user_content, ensure_ascii=False)},
+        ],
+        temperature=0.5,
+    )
+
+    return resp.choices[0].message.content.strip()

--- a/backend/services/questionnaire.py
+++ b/backend/services/questionnaire.py
@@ -1,0 +1,74 @@
+"""Questionnaire loading and assessment utilities."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from fastapi import HTTPException
+
+# Path to questionnaire definitions
+QUESTION_PATH = Path(__file__).resolve().parents[1] / "prompts" / "questionnaires.json"
+
+
+def _load_all() -> Dict[str, List[Dict[str, object]]]:
+    """Load the questionnaire JSON data."""
+    if not QUESTION_PATH.exists():
+        raise HTTPException(status_code=500, detail="Questionnaire definitions not found")
+    with QUESTION_PATH.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def load_questionnaire(module_id: str) -> List[Dict[str, object]]:
+    """Return questionnaire for a module without exposing answers."""
+    data = _load_all()
+    if module_id not in data:
+        raise HTTPException(status_code=404, detail="Module not found")
+    # Strip answers before returning to client
+    questions = []
+    for q in data[module_id]:
+        q_copy = {k: v for k, v in q.items() if k != "answer"}
+        questions.append(q_copy)
+    return questions
+
+
+def evaluate_answers(module_id: str, answers: Dict[str, str]) -> Dict[str, object]:
+    """Evaluate user's answers and assign a level."""
+    data = _load_all()
+    if module_id not in data:
+        raise HTTPException(status_code=404, detail="Module not found")
+
+    questions = data[module_id]
+    total = len(questions)
+    correct = 0
+    weak_topics = []
+
+    # Index questions by id for quick lookup
+    q_map = {q["id"]: q for q in questions}
+
+    for qid, user_answer in answers.items():
+        q = q_map.get(qid)
+        if not q:
+            continue
+        if user_answer.strip().upper() == q["answer"].strip().upper():
+            correct += 1
+        else:
+            weak_topics.append(q.get("topic", qid))
+
+    score = (correct / total) * 100 if total else 0
+    if score >= 70:
+        level = "advanced"
+    elif score >= 40:
+        level = "intermediate"
+    else:
+        level = "beginner"
+
+    recommendations = [f"Review topic: {t}" for t in weak_topics]
+
+    return {
+        "score": round(score, 2),
+        "level": level,
+        "weak_topics": weak_topics,
+        "recommendations": recommendations,
+    }
+


### PR DESCRIPTION
## Summary
- provide assessment API to deliver questionnaires and grade answers
- extend chat service to answer user questions based on skill level
- add questionnaire data and OpenAI prompt config

## Testing
- `pytest`
- `python -m py_compile backend/api/*.py backend/services/*.py backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_689d7f40c488832ebeffb742cc0f5be4