### PR TITLE
Log AI errors in chat endpoint

### DIFF
--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -1,6 +1,11 @@
+import logging
+
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 from services.gpt_call import explain_topic, ask_question
+
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["ai"])
 
@@ -50,4 +55,5 @@ async def ai_ask(payload: ChatIn):
     except HTTPException:
         raise
     except Exception as e:  # noqa: B902
-        raise HTTPException(status_code=500, detail="AI service error") from e
+        logger.exception(e)
+        raise HTTPException(status_code=500, detail=str(e)) from e


### PR DESCRIPTION
## Summary
- add logging setup for the chat API module
- log exceptions and surface error details in `ai_ask`

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d8ebc601c832ea10536af9acaba20