### PR TITLE
Add backend dependencies to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,9 @@
+aiohttp
 fastapi
-uvicorn
 openai
+passlib[bcrypt]
+pyjwt
+pydantic
+python-dotenv
+sqlalchemy
+uvicorn


### PR DESCRIPTION
## Summary
- add aiohttp, SQLAlchemy, python-dotenv, pydantic, PyJWT, and passlib[bcrypt] to backend requirements

## Testing
- `pip install -r requirements.txt` *(fails: 403 Forbidden when accessing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c9f7b338832ea18e6262f8127cfb